### PR TITLE
Regex implementation with nested repeats

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -17,7 +17,7 @@ function unrollRepeats(oldCode) {
 	};
 	// this regex finds "repeat (number) [(string)]" where string doesn't contain [ or ]
 	// only the innermost nesting gets unrolled on each pass through
-	const newCode = oldCode.replace(/repeat\s(\d+)\s\[([^\]\[]+)\]/gmi, regexRepeater);
+	const newCode = oldCode.replace(/repeat\s+(\d+)\s+\[([^\]\[]+)\]/gmi, regexRepeater);
 	// if it hasn't changed any text return it, but if some text has been replaced
 	// call the function again to make sure there isn't another outer level to unroll
 	return oldCode === newCode ? oldCode : unrollRepeats(newCode);
@@ -29,7 +29,7 @@ function goTurtle() {
 	turtle.reset();
 	let code = editor.value();
 	code = unrollRepeats(code);
-	let tokens = code.split(/\s/);
+	let tokens = code.split(/\s+/);
 	let index = 0;
 	while (index < tokens.length) {
 		let token = tokens[index];

--- a/sketch.js
+++ b/sketch.js
@@ -11,12 +11,25 @@ function setup() {
 	goTurtle();
 }
 
+function unrollRepeats(oldCode) {
+	function regexRepeater(_, p1, p2) {
+		return (p2 + ' ').repeat(p1);
+	};
+	// this regex finds "repeat (number) [(string)]" where string doesn't contain [ or ]
+	// only the innermost nesting gets unrolled on each pass through
+	const newCode = oldCode.replace(/repeat\s(\d+)\s\[([^\]\[]+)\]/gmi, regexRepeater);
+	// if it hasn't changed any text return it, but if some text has been replaced
+	// call the function again to make sure there isn't another outer level to unroll
+	return oldCode === newCode ? oldCode : unrollRepeats(newCode);
+}
+
 function goTurtle() {
 	background(0);
 	push();
 	turtle.reset();
 	let code = editor.value();
-	let tokens = code.split(' ');
+	code = unrollRepeats(code);
+	let tokens = code.split(/\s/);
 	let index = 0;
 	while (index < tokens.length) {
 		let token = tokens[index];


### PR DESCRIPTION
This implements the repeat command by unrolling the loops in the string before parsing, like a text-based macro. It handles nested loops with recursion, but it's quite concise so it'd be easy to explain. I also changed the token splitter so that new lines can be used to separate tokens. Try `repeat 36 [lt 10 pu fd 1 pd repeat 120 [fd 2 rt 3]]` for something like the Logo logo on the Wiki page. 

![logo](https://user-images.githubusercontent.com/18706683/47599129-1929d700-d99f-11e8-8968-6184dac05314.png)