### PR TITLE
Fix all the broken things [Issue #54]

### DIFF
--- a/command.js
+++ b/command.js
@@ -38,13 +38,17 @@ class CommandArg {
     if (validator === undefined) {
       switch (type) {
         case ARGUMENT_TYPES.INT:
-          this.validator = (str) => {
-            return /^\d+$/.test(str);
+          this.validator = (arg) => {
+            if (arg instanceof Expression)
+              arg = arg.eval();
+            return /^\d+$/.test(arg);
           }
           break;
         case ARGUMENT_TYPES.FLOAT:
-          this.validator = (str) => {
-            return /^[-+]?[0-9]*\.?[0-9]*$/.test(str);
+          this.validator = (arg) => {
+            if (arg instanceof Expression)
+              arg = arg.eval();
+            return /^[-+]?[0-9]*\.?[0-9]*$/.test(arg);
           }
       }
     } else
@@ -105,10 +109,11 @@ class CommandExecutor {
           this.values.push(value);
           break;
         case ARGUMENT_TYPES.INT:
-          this.values.push(parseInt(value));
+          this.values.push(value);
           break;
         case ARGUMENT_TYPES.FLOAT:
-          this.values.push(parseFloat(value));
+          this.values.push(value);
+          break;
         case ARGUMENT_TYPES.COMMANDS:
           this.values.push(
             new Parser(value, this.callback).parse()
@@ -135,7 +140,7 @@ class CommandExecutor {
     for(let i = 0; i < this.values.length; i++)
     {
       let val = this.values[i];
-      if(this.command.argsTemplate[i].type == COMMAND_TYPES.FLOAT || this.command.argsTemplate[i].type == COMMAND_TYPES.INT)
+      if(this.command.argsTemplate[i].type == ARGUMENT_TYPES.FLOAT || this.command.argsTemplate[i].type == ARGUMENT_TYPES.INT)
       {
         values.push(val.eval(repcount));
       } else {

--- a/command.js
+++ b/command.js
@@ -39,13 +39,13 @@ class CommandArg {
     if (validator === undefined) {
       switch (type) {
         case ARGUMENT_TYPES.INT:
-          this.validator = (arg) => {
-            return /^\d+$/.test(arg);
+          this.validator = (str) => {
+            return /^\d+$/.test(str);
           }
           break;
         case ARGUMENT_TYPES.FLOAT:
-          this.validator = (arg) => {
-            return /^[-+]?[0-9]*\.?[0-9]*$/.test(arg);
+          this.validator = (str) => {
+            return /^[-+]?[0-9]*\.?[0-9]*$/.test(str);
           }
           break;
         case ARGUMENT_TYPES.EXPRESSION:

--- a/command.js
+++ b/command.js
@@ -40,24 +40,20 @@ class CommandArg {
       switch (type) {
         case ARGUMENT_TYPES.INT:
           this.validator = (arg) => {
-            if (arg instanceof Expression)
-              arg = arg.eval();
             return /^\d+$/.test(arg);
           }
           break;
         case ARGUMENT_TYPES.FLOAT:
           this.validator = (arg) => {
-            if (arg instanceof Expression)
-              arg = arg.eval();
             return /^[-+]?[0-9]*\.?[0-9]*$/.test(arg);
           }
-
+          break;
         case ARGUMENT_TYPES.EXPRESSION:
           this.validator = (str) => {
             let res = /^[-+]?([0-9]+\.?[0-9]?|[0-9]*\.?[0-9]+)(\s[+-/*]{1}\s[-+]?([0-9]+\.?[0-9]?|[0-9]*\.?[0-9]+))*$/.test(str);
             return res;
           }
-
+          break;
       }
     } else
       this.validator = validator;
@@ -117,21 +113,19 @@ class CommandExecutor {
           this.values.push(value);
           break;
         case ARGUMENT_TYPES.INT:
-          this.values.push(value);
+          this.values.push(parseInt(value));
           break;
         case ARGUMENT_TYPES.FLOAT:
-          this.values.push(value);
+          this.values.push(parseFloat(value));
           break;
         case ARGUMENT_TYPES.COMMANDS:
           this.values.push(
             new Parser(value, this.callback).parse()
           );
           break;
-
         case ARGUMENT_TYPES.EXPRESSION:
-           //console.log(this.parseExpression(value))
-           this.values.push(this.parseExpression(value).eval())
-
+          this.values.push(this.parseExpression(value).eval());
+          break;
         case ARGUMENT_TYPES.PARAMETERS: // Example
           this.values.push(value.split(" "));
           break;
@@ -152,7 +146,6 @@ class CommandExecutor {
       e = new Expression(next,new Expression('$',token), right);
     } else
       return new Expression('$', token);
-    //console.log(right);
     if (right.lvl() > e.lvl()) {
       let new_left = new Expression(next, new Expression('$',token), right.left);
       e = new Expression(right.type, new_left, right.right);

--- a/expression.js
+++ b/expression.js
@@ -7,8 +7,8 @@ class Expression {
 
   eval() {
     if(this.type == '$') {
-        return parseFloat(this.left);
-    } else if(this.type == '/') { 
+      return parseFloat(this.left);
+    } else if(this.type == '/') {
       return this.left.eval() / this.right.eval();
     } else if(this.type == '*') {
       return this.left.eval() * this.right.eval();

--- a/index.html
+++ b/index.html
@@ -46,10 +46,6 @@
 		Icons made by <a href="https://www.flaticon.com/authors/freepik" title="Turtle">Turtle</a> from <a href="https://www.flaticon.com/"     title="Flaticon">www.flaticon.com</a> is licensed by <a href="http://creativecommons.org/licenses/by/3.0/"     title="Creative Commons BY 3.0" target="_blank">CC 3.0 BY</a>
 	</small>
 
-	<script>
-		document.querySelector("#code").value = "pu lt 90 fd 100 lt 90 fd 250 rt 90 rt 90 pd fd 500 rt 90 fd 150 rt 90 fd 500 rt 90 fd 150";
-	</script>
-
 	<script src="sketch.js"></script>
 </body>
 

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
     <script src="expression.js"></script>
     <script src="parser.js"></script>
     <script src="command.js"></script>
+    <script src="commandList.js"></script>
     <script src="bounding_box.js"></script>
 
     <link rel="stylesheet" href="./style.css">
@@ -33,22 +34,22 @@
             <img src="./assets/img/color.svg" style="width: 30px; height: 30px; padding: 2px;" alt="">
         </span>
 	</div>
-	
+
 	<!-- Canvas div -->
 	<div id="logo-canvas"></div>
-	
+
 	<!-- Editor -->
 	<textarea id="code" cols="40" rows="4" autocomplete="false" spellcheck="false" autofocus></textarea>
-	
+
 	<!-- Icon Copyright info -->
 	<small style="color: white; font-family: 'Montserrat'; padding-top: 10px;">
 		Icons made by <a href="https://www.flaticon.com/authors/freepik" title="Turtle">Turtle</a> from <a href="https://www.flaticon.com/"     title="Flaticon">www.flaticon.com</a> is licensed by <a href="http://creativecommons.org/licenses/by/3.0/"     title="Creative Commons BY 3.0" target="_blank">CC 3.0 BY</a>
 	</small>
-	
+
 	<script>
 		document.querySelector("#code").value = "pu lt 90 fd 100 lt 90 fd 250 rt 90 rt 90 pd fd 500 rt 90 fd 150 rt 90 fd 500 rt 90 fd 150";
 	</script>
-	
+
 	<script src="sketch.js"></script>
 </body>
 

--- a/parser.js
+++ b/parser.js
@@ -80,7 +80,7 @@ class Parser {
       e = new Expression(next, token, right);
     } else if(next == '+' || next == '-') {
       right = this.parseExpression();
-      e = new Expression(next, token, right); 
+      e = new Expression(next, token, right);
     } else {
       this.index = temp;
       return token;
@@ -102,25 +102,28 @@ class Parser {
   parse() {
     let cmdsExecutors = [];
     while (this.remainingTokens()) {
- 
       let token = this.nextToken();
-      let cmd = commandLookUp.get(token);;
+      let cmd = commandLookUp.get(token);
       if (cmd) {
         let args = [];
         for (let i = 0; i < cmd.argsTemplate.length; i++) {
           let startIndex = this.index;
           let arg = cmd.argsTemplate[i];
-          let theArgToken = this.nextToken();
+          let theArgToken;
           if(arg.type == ARGUMENT_TYPES.FLOAT || arg.type == ARGUMENT_TYPES.INT) {
             theArgToken = this.parseExpression();
-          if(arg.validator !== undefined){
-            if(!arg.validator(theArgToken))
-              console.error(`Argument number ${i} (${theArgToken}) is invalid for command ${token}`);
+            if(arg.validator !== undefined){
+              if(!arg.validator(theArgToken))
+                console.error(`Argument number ${i} (${theArgToken}) is invalid for command ${token}`);
+              args.push(theArgToken);
+            }
+            else {
+              args.push(theArgToken);
+              console.warn(`A validator is missing for argument ${theArgToken}`);
+            }
+          } else {
+            theArgToken = this.nextToken();
             args.push(theArgToken);
-          }
-          else {
-            args.push(theArgToken);
-            console.warn(`A validator is missing for argument ${theArgToken}`);
           }
         }
         cmdsExecutors.push(new CommandExecutor(cmd, args, this.afterCmdCallback));

--- a/sketch.js
+++ b/sketch.js
@@ -64,6 +64,7 @@ function setup() {
   }
 
   editor = select("#code");
+  setDefaultDrawing();
   editor.input(goTurtle);
   scaleToFitBoundingBox(drawingBounds); // This also redraws (it has to in order to measure the size of the drawing)
 }
@@ -109,9 +110,17 @@ function goTurtle() {
   pop();
 }
 
+/**
+ * Writes the Logo code for the default drawing to the textarea
+ * Called on page load
+ * Also called when selecting the default item from the #testdata dropdown
+ */
+function setDefaultDrawing() {
+  editor.value("pu lt 90 fd 100 lt 90 fd 250 rt 90 rt 90 pd fd 500 rt 90 fd 150 rt 90 fd 500 rt 90 fd 150");
+}
+
 function createTestDataView(cases) {
   let selector = select("#testdata");
-  allCases = cases;
 
   selector.option("Logo Default", -1);
 
@@ -123,30 +132,26 @@ function createTestDataView(cases) {
   selector.changed(function() {
     let val = parseInt(selector.value());
     if (val < 0) {
-      turtle.strokeColor = 255;
-      turtle.dir = 0;
-      turtle.x = 0;
-      turtle.y = 0;
-      canvasScrollX = 0;
-      canvasScrollY = 0;
-      canvasScaleX = 1;
-      canvasScaleY = 1;
-
-      goTurtle();
-      return;
+      // Use the default drawing
+      setDefaultDrawing();
+    } else {
+      // Use a drawing from tests.json
+      editor.value(cases[val].code);
     }
 
-    editor.value(allCases[val].code);
-
+    // Reset default parameters for turtle
     turtle.strokeColor = 255;
     turtle.dir = 0;
     turtle.x = 0;
     turtle.y = 0;
 
+    // Reset default parameters for camera
     canvasScrollX = 0;
     canvasScrollY = 0;
     canvasScaleX = 1;
     canvasScaleY = 1;
+
+    // Move and scale the drawing to fit on-screen
     scaleToFitBoundingBox(drawingBounds);
   });
 }

--- a/sketch.js
+++ b/sketch.js
@@ -109,10 +109,6 @@ function goTurtle() {
 
   pop();
 
-  noFill();
-  stroke(255, 0, 0);
-  rect(drawingBounds.left, drawingBounds.top, drawingBounds.width, drawingBounds.height);
-
   pop();
 }
 

--- a/turtle.js
+++ b/turtle.js
@@ -34,6 +34,6 @@ class Turtle {
 
   home() {
     this.x = this.homeX;
-    this.y = this.homey;
+    this.y = this.homeY;
   }
 }


### PR DESCRIPTION
Man! This was so spaghetti'd I'm now Italian...

These were the issues:

- Someone removed a break from the switch statement in the constructor of CommandExecutor which meant that float values were pushed to the argument list twice (once as a float and then again as a command).

- In Parser.parse() someone moved the call to nextToken() out of the else condition so that it is always executed.
  The intended functionality is to call parseExpression() when the argument type is int or float.
  After this change nextToken() was always executed regardless, then parseExpression was executed as well if the expression was an int or float, causing arguments to get skipped resulting in attempts to invoke numbers as if they were commands.

- COMMAND_TYPES was renamed to ARGUMENT_TYPES but not everywhere causing ReferenceErrors

- #30 Removed calls to parseInt() and parseFloat() in the CommandExecutor constructor because an argument may be an Expression object. #52 Added them back causing Expression objects to become NaN

- Missing brace at end of parser.js

- #52 also removed the calls to drawingBounds.reset() and drawingBounds.move(turtle.x, turtle.y) which obviously broke the autofit-drawing-to-canvas feature

- The autofit-drawing-to-canvas feature was also broken because someone removed the call to the scaleToFitBoundingBox function ¯\\\_(ツ)\_/¯

- The commandList.js script tag got removed