### PR TITLE
Fixed random bgColor hexadecimal value were white sometimes.

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -74,8 +74,12 @@ function setup() {
     let r = floor(random(0, 255));
     let g = floor(random(0, 255));
     let b = floor(random(0, 255));
-
-    let col = `#${r.toString(16)}${g.toString(16)}${b.toString(16)}`;
+    
+    let hexR = `${r <= 15 ? '0' : ''}${r.toString(16)}`;
+    let hexG = `${g <= 15 ? '0' : ''}${g.toString(16)}`;
+    let hexB = `${b <= 15 ? '0' : ''}${b.toString(16)}`;
+    
+    let col = `#${hexR}${hexG}${hexB}`;
     bgcolor = col;
     goTurtle();
   }


### PR DESCRIPTION
There was a problem with random background color, it showed a white background because sometimes some RGB value was equal or below to 15, then when it was converted to hexadecimal, it didn't contain the corresponding 0 to make a well known hexadecimal value. Shown in the picture below.

![randomcolorbug](https://user-images.githubusercontent.com/24358434/48512315-6cf94480-e816-11e8-8506-7ee1bc648e44.png)

Then with the little fix it shows the correct background color.
Edit note: The values for RGB on the next image are the same of the previous image.

![randomcolorbugfixed](https://user-images.githubusercontent.com/24358434/48512365-88fce600-e816-11e8-941e-c9cb375eb2d1.png)
