### PR TITLE
Fix editor overlay scrollbar

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -40,11 +40,17 @@ function getCanvasSize() {
   return { width: bounds.width, height: bounds.height };
 }
 
+function updateEditorOverlayMargin() {
+  const editorBounds = select('#editor-container').elt.getBoundingClientRect();
+  editor_bg.elt.style.right = `${editorBounds.width - editor.elt.scrollWidth - 3}px`;
+}
+
 function windowResized() {
   const canvasSize = getCanvasSize();
   resizeCanvas(canvasSize.width, canvasSize.height);
   updateResizeHandlePosition();
   scaleToFitBoundingBox(drawingBounds);
+  updateEditorOverlayMargin();
 }
 
 function setup() {
@@ -101,7 +107,6 @@ function setup() {
   scaleToFitBoundingBox(drawingBounds); // This also redraws (it has to in order to measure the size of the drawing)
 
   editor.elt.addEventListener('scroll', ev => {
-    console.log(`scroll: ${editor.elt.scrollTop}`);
     select('#code_bg').elt.scrollTop = editor.elt.scrollTop;
   }, { passive: true }); // The 'passive: true' parameter increases performance when scrolling by making it impossible to cancel the scroll events
 }
@@ -147,8 +152,6 @@ function goTurtle() {
     }
   } catch (err) {
     showError(err.startIndex,err.endIndex);
-    console.log(err);
-
   }
 
   pop();
@@ -199,6 +202,8 @@ function createTestDataView(cases) {
 
     // Move and scale the drawing to fit on-screen
     scaleToFitBoundingBox(drawingBounds);
+
+    updateEditorOverlayMargin()
   });
 }
 

--- a/style.css
+++ b/style.css
@@ -86,7 +86,7 @@ a {
     overflow: hidden;
     margin: 0 10px 0 9px;
     width: 99%;
-    width: Calc(100% - 22px);
+    width: Calc(100% - 18px);
     min-height: 6em;
     outline: none;
     border-radius: 10px;
@@ -104,11 +104,11 @@ a {
 }
 
 #code {
-    width: Calc(100% - 36px);
+    width: Calc(100% - 34px);
     height: Calc(100% - 11px);
     font-size: 20px;
     font-family: 'Courier New', Courier, monospace;
-    padding: 5px 20px 0 10px;
+    padding: 5px 18px 0 10px;
     outline: none;
     border-radius: 10px;
     border: 3px solid rgba(83, 81, 81, 0.6);
@@ -124,15 +124,16 @@ a {
     position: absolute;
     top: 3px;
     left: 3px;
-    right: 20px;
+    right: 3px;
     bottom: 0;
     overflow: hidden;
     font-family: 'Courier New', Courier, monospace;
     resize: none;
     white-space: pre-wrap;
-	word-wrap: break-word;
+    word-wrap: break-word;
     font-size: 20px;
-    padding: 5px 20px 0 10px;
+    padding: 5px 18px 0 10px;
+    color: transparent;
     background-color:#1f2223;
 }
 


### PR DESCRIPTION
The text in the editor overlay would sometimes wrap differently to the text in the editor itself depending on whether or not there was a scrollbar.
This didn't always happen and behaved differently in chrome and firefox.