### PR TITLE
Fix radians command.

### DIFF
--- a/turtle.js
+++ b/turtle.js
@@ -18,8 +18,8 @@ class Turtle {
 
   forward(amt) {
     // Move the turtle
-    this.x += Math.cos(this.dir * Math.PI / 180) * amt;
-    this.y += Math.sin(this.dir * Math.PI / 180) * amt;
+    this.x += cos(this.dir) * amt;
+    this.y += sin(this.dir) * amt;
 
     // If the pen is down we should draw a line from the previous position to the new position
     if (this.pen) {


### PR DESCRIPTION
Commit 5502ec2397cfafb39ad9a88896f735037fccfd46 to fix issue #68 broke the `radians` command.
Simply stopped using `Math.sin()` and `Math.cos()` and instead used the p5.js `sin()` and `cos()` global functions which take into account the p5.js `angleMode()`.